### PR TITLE
Allow to change or disable polling security status 

### DIFF
--- a/authoritative/docker-entrypoint.sh
+++ b/authoritative/docker-entrypoint.sh
@@ -56,6 +56,8 @@ if [ "$1" = "pdns_server" ] && [ ! -f /etc/pdns/pdns.conf ]; then
     sed -i "s|# webserver-password=|webserver-password=${AUTHORITATIVE_WEBSERVER_PASSWORD:-pdns}|g" /etc/pdns/pdns.conf
     sed -i "s|# webserver-port=8081|webserver-port=8081|g" /etc/pdns/pdns.conf
 
+    sed -i "s|# security-poll-suffix=.*|security-poll-suffix=${RECURSOR_SECURITY_POOL_SUFFIX:-secpoll.powerdns.com.}|g" /etc/pdns/pdns.conf
+
     sed -i "s|# launch=|launch=gpgsql|g" /etc/pdns/pdns.conf
     echo "gpgsql-user=${AUTHORITATIVE_DB_USER:-pdns}" >> /etc/pdns/pdns.conf
     echo "gpgsql-host=${AUTHORITATIVE_DB_HOST:-authoritative-db}" >> /etc/pdns/pdns.conf

--- a/recursor/docker-entrypoint.sh
+++ b/recursor/docker-entrypoint.sh
@@ -38,6 +38,8 @@ if [ "$1" = "pdns_recursor" ] && [ ! -f /etc/pdns-recursor/recursor.conf ]; then
     sed -i "s|# webserver-password=|webserver-password=${RECURSOR_WEBSERVER_PASSWORD:-pdns}|g" /etc/pdns-recursor/recursor.conf
     sed -i "s|# webserver-port=8082|webserver-port=8082|g" /etc/pdns-recursor/recursor.conf
 
+    sed -i "s|# security-poll-suffix=.*|security-poll-suffix=${RECURSOR_SECURITY_POOL_SUFFIX:-secpoll.powerdns.com.}|g" /etc/pdns-recursor/recursor.conf
+
     echo "pdnslog('Loading Lua Configuration')" > /etc/pdns-recursor/config.lua
     if [ -n "${RECURSOR_TRUST_ANCHORS}" ]; then
         echo "${RECURSOR_TRUST_ANCHORS//,/$'\n'}" | while read anchor ; do


### PR DESCRIPTION
https://doc.powerdns.com/authoritative/security.html#security-polling

Add en environment variable to recursor/authoritative service to disable polling Security updates
```yaml
    environment:
      - RECURSOR_SECURITY_POOL_SUFFIX=
```

It will fix this issues
```
Failed to retrieve security status update for on security-status.secpoll.powerdns.com.'
```